### PR TITLE
Option for time-average of block spatial jacobian in the DiagFFTPC

### DIFF
--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -103,7 +103,7 @@ class paradiag(object):
                  form_function, form_mass, W, w0, dt, theta,
                  alpha, M, solver_parameters=None,
                  circ="picard",
-                 jac_average="newton", tol=1.0e-6, maxits=10,
+                 tol=1.0e-6, maxits=10,
                  ctx={}, block_mat_type="aij"):
         """A class to implement paradiag timestepping.
 
@@ -125,11 +125,7 @@ class paradiag(object):
         form relaxation method. "quasi" - do a modified Newton
         method with alpha-circulant modification added to the
         Jacobian. To make the alpha circulant modification only in the
-       preconditioner, simply set ksp_type:preonly in the solve options.
-        :arg jac_average: a string describing the option for when to
-        average the jacobian. "newton" - make a quasi-Newton method by
-        time averaging the Jacobian. "preconditioner" - only do the
-        average in the preconditioner.
+        preconditioner, simply set ksp_type:preonly in the solve options.
         :arg tol: float, the tolerance for the relaxation method (if used)
         :arg maxits: integer, the maximum number of iterations for the
         relaxation method, if used.
@@ -153,7 +149,6 @@ class paradiag(object):
         self.tol = tol
         self.maxits = maxits
         self.circ = circ
-        self.jac_average = jac_average
 
         # A coefficient that switches the alpha-circulant term on
         self.Circ = fd.Constant(1.0)

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -102,7 +102,7 @@ def test_linear_swe_FFT():
                       alpha=alpha,
                       M=M, solver_parameters=solver_parameters_diag,
                       circ="quasi",
-                      jac_average="newton", tol=1.0e-6, maxits=None,
+                      tol=1.0e-6, maxits=None,
                       ctx={}, block_mat_type="aij")
     PD.solve()
     assert (1 < PD.snes.getConvergedReason() < 5)
@@ -154,7 +154,7 @@ def test_jacobian_heat_equation():
                       alpha=alpha,
                       M=M, solver_parameters=solver_parameters,
                       circ="none",
-                      jac_average="newton", tol=1.0e-6, maxits=None)
+                      tol=1.0e-6, maxits=None)
 
     PD.solve()
 
@@ -196,7 +196,7 @@ def test_set_para_form():
                       alpha=alpha,
                       M=M, solver_parameters=solver_parameters,
                       circ="none",
-                      jac_average="newton", tol=1.0e-6, maxits=None,
+                      tol=1.0e-6, maxits=None,
                       ctx={}, block_mat_type="aij")
 
     # sequential assembly
@@ -297,7 +297,7 @@ def test_set_para_form_mixed_parallel():
                       alpha=alpha,
                       M=M, solver_parameters=solver_parameters,
                       circ="none",
-                      jac_average="newton", tol=1.0e-6, maxits=None,
+                      tol=1.0e-6, maxits=None,
                       ctx={}, block_mat_type="aij")
 
     # sequential assembly
@@ -422,7 +422,7 @@ def test_jacobian_mixed_parallel():
                       alpha=alpha,
                       M=M, solver_parameters=solver_parameters,
                       circ="none",
-                      jac_average="newton", tol=1.0e-6, maxits=None,
+                      tol=1.0e-6, maxits=None,
                       ctx={}, block_mat_type="aij")
 
     # sequential assembly


### PR DESCRIPTION
This adds an extra option to the paradiag solver parameters that gets passed through to the preconditioner.
This option determines whether the block spatial jacobian is calculated from a global (window) time-average of the solution or a local (slice) time-average