### PR TITLE
Fix nonlinear updates

### DIFF
--- a/asQ/paradiag.py
+++ b/asQ/paradiag.py
@@ -49,9 +49,6 @@ class JacobianMatrix(object):
                                         paradiag.w_recv)
 
     def mult(self, mat, X, Y):
-        # update the contents of paradiag.u from paradiag.X
-        self.paradiag.update(self.paradiag.X)
-
         n = self.n
 
         # copy the local data from X into self.u
@@ -221,6 +218,7 @@ class paradiag(object):
         def form_jacobian(snes, X, J, P):
             # copy the snes state vector into self.X
             X.copy(self.X)
+            self.update(X)
             J.assemble()
             P.assemble()
 

--- a/tests/test_paradiag.py
+++ b/tests/test_paradiag.py
@@ -551,6 +551,7 @@ def test_jacobian_mixed_parallel():
     # copy from w_all into the PETSc vec PD.X
     with PD.w_all.dat.vec_ro as v:
         v.copy(PD.X)
+    PD.update(PD.X)
 
     # use PD to calculate the Jacobian
     Jac1 = PD.JacobianMatrix


### PR DESCRIPTION
In the Jacobian apply() method we are currently updating the solution state from the input X, which is wrong, because X is a linear increment within the Krylov method, not the solution state we are linearising around.
I removed this, and put in an update() in form_jacobian, which is a callback from PETSc that is called by the snes before doing the ksp solve.